### PR TITLE
Fix type

### DIFF
--- a/src/test/java/net/nagaseyasuhito/sandbox/AwesomeAsyncServiceTest.java
+++ b/src/test/java/net/nagaseyasuhito/sandbox/AwesomeAsyncServiceTest.java
@@ -16,10 +16,10 @@ import lombok.extern.java.Log;
 public class AwesomeAsyncServiceTest {
 
 	@Autowired
-	private AwesomeAsyncService awesomeAsyncService;
+	private AsyncService asyncService;
 
 	@Test
 	public void test() throws InterruptedException, ExecutionException {
-		log.info(this.awesomeAsyncService.process("nagaseyasuhito").get());
+		log.info(this.asyncService.process("nagaseyasuhito").get());
 	}
 }


### PR DESCRIPTION
Because `@Async` is annotated on `AwesomeAsyncService`, proxy class is created. If interface is implemented, JDK proxy is used as default behavior.  

Proxy looks like as follows

``` java
public class Proxy$1 implements AsyncService {
  AwesomeAsyncService asyncService;

  public ComplatableFuture process(String s) {
    // do something
    ComplatableFuture ret = this.asyncService.process(s);
    // do something
    return ret;
  }
}

```

So this proxy is not `AwesomeAsyncService` but `AsyncService`. 

`@EnableAsync(proxyTargetClass = true)` will also work. This option forces DI container to  create a proxy by **subclassing** using CGLIB.

In this case, proxy looks like

``` java
public class Proxy$1 extends AwesomeAsyncService {

  public ComplatableFuture process(String s) {
    // do something
    ComplatableFuture ret = super.process(s);
    // do something
    return ret;
  }
}
```
